### PR TITLE
Adding support for external model uris

### DIFF
--- a/src/commons/loadWeightMap.ts
+++ b/src/commons/loadWeightMap.ts
@@ -16,6 +16,8 @@ export function getModelUris(uri: string | undefined, defaultModelName: string) 
       manifestUri: `/${defaultManifestFilename}`
     }
   }
+  const protocol = uri.startsWith('http://') ? 'http://' : uri.startsWith('https://') ? 'https://' : '';
+  uri = uri.replace(protocol, '');
 
   const parts = uri.split('/').filter(s => s)
 
@@ -23,7 +25,7 @@ export function getModelUris(uri: string | undefined, defaultModelName: string) 
     ? parts[parts.length - 1]
     : defaultManifestFilename
 
-  let modelBaseUri = (uri.endsWith('.json') ? parts.slice(0, parts.length - 1) : parts).join('/')
+  let modelBaseUri = protocol + (uri.endsWith('.json') ? parts.slice(0, parts.length - 1) : parts).join('/')
   modelBaseUri = uri.startsWith('/') ? `/${modelBaseUri}` : modelBaseUri
 
   return {

--- a/test/tests/commons/loadWeightMap.test.ts
+++ b/test/tests/commons/loadWeightMap.test.ts
@@ -59,6 +59,14 @@ describe('loadWeightMap', () => {
       expect(result.modelBaseUri).toEqual('/path/to/modelfiles')
     })
 
+    it('returns correct uris, given external path', () => {
+      const uri = 'https://example.com/path/to/modelfiles/';
+      const result = getModelUris(uri, FAKE_DEFAULT_MODEL_NAME)
+
+      expect(result.manifestUri).toEqual(uri + 'model-weights_manifest.json')
+      expect(result.modelBaseUri).toEqual(uri)
+    })
+
   })
 
 })


### PR DESCRIPTION
This PR adds a check in getModelUris for external addresses (those starting with a http protocol).

If a protocol is present it is removed from the uri string, and re added when creating the final modelBaseUri .
This should allow for the use of any external uri to load models. 

The PR also includes a new test case to cover this type of loading.