### PR TITLE
use `locateFaces()` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ const maxResults = 10
 
 // inputs can be html canvas, img or video element or their ids ...
 const myImg = document.getElementById('myImg')
-const detections = await faceapi.ssdMobilenetv1(myImg, minConfidence, maxResults)
+const detections = await faceapi.locateFaces(myImg, minConfidence, maxResults)
 ```
 
 Draw the detected faces to a canvas:


### PR DESCRIPTION
Looks like`ssdMobilenetv1()` is deprecated. I couldn't see it being exposed on `faceapi` object. Seems like `locateFaces()` serves the same purpose and has the same signature. 