### PR TITLE
ci: test on Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 sudo: required
 language: node_js
 node_js:
+  - "node"
   - "10"
+  - "8"
+  - "6"
 env:
   - BACKEND_CPU=true EXCLUDE_UNCOMPRESSED=true
 addons:


### PR DESCRIPTION
We should test all LTS and stable releases to make sure if these are supported, which are not and catch breaking builds early.