### PR TITLE
ci: use npm install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   - BACKEND_CPU=true EXCLUDE_UNCOMPRESSED=true
 addons:
   chrome: stable
+install: npm install
 before_install:
  - export DISPLAY=:99.0
  - sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
To prevent that `npm ci` is used which may have different outcomes compared to `npm install`.