### PR TITLE
Fixing issue #222: FaceLandmarks68 left and right eyes/brows are reversed.

### DIFF
--- a/src/classes/FaceLandmarks68.ts
+++ b/src/classes/FaceLandmarks68.ts
@@ -7,11 +7,11 @@ export class FaceLandmarks68 extends FaceLandmarks {
     return this.positions.slice(0, 17)
   }
 
-  public getLeftEyeBrow(): Point[] {
+  public getRightEyeBrow(): Point[] {
     return this.positions.slice(17, 22)
   }
 
-  public getRightEyeBrow(): Point[] {
+  public getLeftEyeBrow(): Point[] {
     return this.positions.slice(22, 27)
   }
 
@@ -19,11 +19,11 @@ export class FaceLandmarks68 extends FaceLandmarks {
     return this.positions.slice(27, 36)
   }
 
-  public getLeftEye(): Point[] {
+  public getRightEye(): Point[] {
     return this.positions.slice(36, 42)
   }
 
-  public getRightEye(): Point[] {
+  public getLeftEye(): Point[] {
     return this.positions.slice(42, 48)
   }
 

--- a/test/tests/faceLandmarkNet/faceLandmark68Net.test.ts
+++ b/test/tests/faceLandmarkNet/faceLandmark68Net.test.ts
@@ -60,6 +60,14 @@ describe('faceLandmark68Net', () => {
         const { x, y } = faceLandmarkPositionsRect[i]
         expectPointClose(pt, { x, y }, 6)
       })
+      expect(
+        Math.max(...result.getRightEyeBrow().map(_=>_.x)) < 
+        Math.min(...result.getLeftEyeBrow().map(_=>_.x))
+      ).toBe(true);
+      expect(
+        Math.max(...result.getRightEye().map(_=>_.x)) < 
+        Math.min(...result.getLeftEye().map(_=>_.x))
+      ).toBe(true);
     })
 
   })


### PR DESCRIPTION
NOTE: this is a "blind" fix, as I failed to build the library and run unit tests on my Windows box without Python (and I have no interest to install it). Up to you to verify and correct it.