### PR TITLE
fix video not showing on iOS Safari by playsinline

### DIFF
--- a/examples/examples-browser/views/videoFaceTracking.html
+++ b/examples/examples-browser/views/videoFaceTracking.html
@@ -17,7 +17,7 @@
       <div class="indeterminate"></div>
     </div>
     <div style="position: relative" class="margin">
-      <video src="bbt.mp4" id="inputVideo" autoplay muted loop></video>
+      <video src="bbt.mp4" id="inputVideo" autoplay muted loop playsinline></video>
       <canvas id="overlay" />
     </div>
 

--- a/examples/examples-browser/views/webcamAgeAndGenderRecognition.html
+++ b/examples/examples-browser/views/webcamAgeAndGenderRecognition.html
@@ -17,7 +17,7 @@
       <div class="indeterminate"></div>
     </div>
     <div style="position: relative" class="margin">
-      <video onloadedmetadata="onPlay(this)" id="inputVideo" autoplay muted></video>
+      <video onloadedmetadata="onPlay(this)" id="inputVideo" autoplay muted playsinline></video>
       <canvas id="overlay" />
     </div>
 

--- a/examples/examples-browser/views/webcamFaceDetection.html
+++ b/examples/examples-browser/views/webcamFaceDetection.html
@@ -17,7 +17,7 @@
       <div class="indeterminate"></div>
     </div>
     <div style="position: relative" class="margin">
-      <video onloadedmetadata="onPlay(this)" id="inputVideo" autoplay muted></video>
+      <video onloadedmetadata="onPlay(this)" id="inputVideo" autoplay muted playsinline></video>
       <canvas id="overlay" />
     </div>
 

--- a/examples/examples-browser/views/webcamFaceExpressionRecognition.html
+++ b/examples/examples-browser/views/webcamFaceExpressionRecognition.html
@@ -17,7 +17,7 @@
       <div class="indeterminate"></div>
     </div>
     <div style="position: relative" class="margin">
-      <video onloadedmetadata="onPlay(this)" id="inputVideo" autoplay muted></video>
+      <video onloadedmetadata="onPlay(this)" id="inputVideo" autoplay muted playsinline></video>
       <canvas id="overlay" />
     </div>
 

--- a/examples/examples-browser/views/webcamFaceLandmarkDetection.html
+++ b/examples/examples-browser/views/webcamFaceLandmarkDetection.html
@@ -17,7 +17,7 @@
       <div class="indeterminate"></div>
     </div>
     <div style="position: relative" class="margin">
-      <video onloadedmetadata="onPlay(this)" id="inputVideo" autoplay muted></video>
+      <video onloadedmetadata="onPlay(this)" id="inputVideo" autoplay muted playsinline></video>
       <canvas id="overlay" />
     </div>
 


### PR DESCRIPTION
Hi Vincent,

In the browser example code, I found videos are not showing properly on iOS safari, like black screens or not auto played... These bugs could be fixed by simply add playsinline attribute to the video tag for the iOS 10 afterwards. For iOS 9 onwards could use library like iphone-inline-video.

Thanks.
Leo
