### PR TITLE
fix env to work in electron correctly

### DIFF
--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -22,10 +22,10 @@ function initialize() {
   // check for isBrowser() first to prevent electron renderer process
   // to be initialized with wrong environment due to isNodejs() returning true
   if (isBrowser()) {
-    setEnv(createBrowserEnv())
+    return setEnv(createBrowserEnv())
   }
   if (isNodejs()) {
-    setEnv(createNodejsEnv())
+    return setEnv(createNodejsEnv())
   }
 }
 


### PR DESCRIPTION
The problem is: electron env includes and browser and nodejs together.
Therefore, both isBrowser and isNodejs function will return true.
The comment in the code mentions, that isBrowser is explictly called first
to prevent electron renderer process to be initialized with
wrong environment due to isNodejs() returning true.
But current code (before the change) executes both isBrowser and isNodejs blocks.
This commit resolves the issue.