### PR TITLE
Examples: restrict UI controls for scoreThreshold, minConfidence

### DIFF
--- a/examples/examples-browser/public/js/faceDetectionControls.js
+++ b/examples/examples-browser/public/js/faceDetectionControls.js
@@ -18,7 +18,7 @@ function getFaceDetectorOptions() {
 }
 
 function onIncreaseMinConfidence() {
-  minConfidence = Math.min(faceapi.utils.round(minConfidence + 0.1), 1.0)
+  minConfidence = Math.min(faceapi.utils.round(minConfidence + 0.1), 0.9)
   $('#minConfidence').val(minConfidence)
   updateResults()
 }
@@ -43,7 +43,7 @@ function changeInputSize(size) {
 }
 
 function onIncreaseScoreThreshold() {
-  scoreThreshold = Math.min(faceapi.utils.round(scoreThreshold + 0.1), 1.0)
+  scoreThreshold = Math.min(faceapi.utils.round(scoreThreshold + 0.1), 0.9)
   $('#scoreThreshold').val(scoreThreshold)
   updateResults()
 }


### PR DESCRIPTION
I noticed that the examples were crashing when the user hit the plus button next to `scoreThreshold` or `minConfidence` settings, because at one point it will set them to `1`. Both settings should be `< 1`.
 
I checked how this was solved on [the official demo page of face-api.js](https://github.com/justadudewhohacks/face-api.js-github.io/blob/7face359cc371d01fb5f08c3381800ff6a02ddbe/src/components/FaceDetectorSelection/TinyFaceDetectorControls.tsx#L53): By setting the upper bound to 0.9. That's what I did here too.
