### PR TITLE
Made python requirement version specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Now we simply monkey patch the environment to use the polyfills:
 
 ``` javascript
 // import nodejs bindings to native tensorflow,
-// not required, but will speed up things drastically (python required)
+// not required, but will speed up things drastically (python 2.7 required)
 import '@tensorflow/tfjs-node';
 
 // implements nodejs wrappers for HTMLCanvasElement, HTMLImageElement, ImageData


### PR DESCRIPTION
@tensorflow/tfjs-node requires version 2.7 specifically. Bindings won't be applied properly with 3.x and install will fail. Will save people from debugging install errors.